### PR TITLE
fix: add Init method on backward compat

### DIFF
--- a/asn.go
+++ b/asn.go
@@ -89,3 +89,5 @@ func (backwardCompat) AsnForIPv6(ip net.IP) (string, error) {
 	}
 	return strconv.FormatUint(uint64(asn), 10), nil
 }
+
+func (backwardCompat) Init() {}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.0"
+  "version": "v0.4.1"
 }


### PR DESCRIPTION
I broke the API eventho I didn't meant to, I thought I was safe because the gorelease bot didn't reported anything but it seems to be wrong: https://github.com/libp2p/go-libp2p-asn-util/pull/33#issuecomment-1862759607

> gocompat says:
> ```
> Your branch is up to date with 'origin/master'.
> ```